### PR TITLE
[DEL]measureHeightOnceの廃止

### DIFF
--- a/ESP32/lib/DPSdriver/include/DPS.hpp
+++ b/ESP32/lib/DPSdriver/include/DPS.hpp
@@ -3,6 +3,19 @@
 #include "SPIbus.hpp"
 #include "../util/dps_register.hpp"
 #include "../util/dps_const.hpp"
+#include <math.h>
+
+static float calc_height_sub(float P)
+{
+    float P_hP = P/100.0;
+    const float k_const = 1.0/5.257;
+    if (P_hP != 0)
+    {
+        float H_raw = pow(DPS__SEA_LEVEL_PRESSURE/P_hP,k_const);
+        return H_raw;
+    }
+    return 0;
+}
 
 #define DPS_ERR_CHECK(x) (x)
 namespace dps
@@ -75,7 +88,6 @@ namespace dps
         dps_err_t measureTempOnce(float &result);
         dps_err_t measurePressureOnce(float &result, uint8_t oversamplingRate);
         dps_err_t measurePressureOnce(float &result);
-        dps_err_t measureHeightOnce(float &result);
     };
     
     

--- a/ESP32/lib/DPSdriver/src/DPS.cpp
+++ b/ESP32/lib/DPSdriver/src/DPS.cpp
@@ -264,21 +264,4 @@ namespace dps
 	{
 		return measurePressureOnce(result, m_prsOsr);
 	}
-
-    dps_err_t DPS::measureHeightOnce(float &result)
-	{
-		float T, P;
-		dps_err_t ret = measureTempOnce(T);
-		if (ret != DPS__SUCCEEDED)
-		{
-			return ret;
-		}
-		ret = measurePressureOnce(P);
-		if (ret != DPS__SUCCEEDED)
-		{
-			return ret;
-		}
-		result = (std::pow((DPS__SEA_LEVEL_PRESSURE/(P/100)),(1.0/5.257)) - 1)*(T + 273.15)/0.0065;
-		return ret;
-	}
 } // namespace dps

--- a/ESP32/src/main.cpp
+++ b/ESP32/src/main.cpp
@@ -16,6 +16,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include "math.h"
 
 #define SPI_CLOCK   10000000  // 10 MHz
 #define SPI_MODE    3
@@ -43,19 +44,18 @@ extern "C" void app_main()
     dps310::DPS310 myDPS(&mySPI, CS_PIN);
     myDPS.dev_init(SPI_MODE,SPI_CLOCK,CS_PIN);
     myDPS.setTmpOversamplingRate(1);
+    myDPS.setPrsOversamplingRate(1);
 
-    myDPS.initiarize();
+    dps::dps_err_t ret = myDPS.initiarize();
+    printf("ret=%d\n",ret);
+    if (ret != dps::DPS__SUCCEEDED)
+    {
+        return;
+    }
+    
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
     while (1)
     {
-        float T_comp=0;
-        myDPS.measureTempOnce(T_comp);
-        printf("T=%f\n",T_comp);
-        float P=0;
-        myDPS.measurePressureOnce(P);
-        printf("P=%f\n",P);
-        float H = 0;
-        myDPS.measureHeightOnce(H);
-        printf("H=%f\n",H);
-        vTaskDelay(20 / portTICK_PERIOD_MS);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
 }


### PR DESCRIPTION
measureHeightOnceは廃止します. 理由としてはfloat周りの計算をDPS310クラス内で行うとDPS310内のエラー状態を保持する変数に影響を与え、正常に動作しないからです. この原因は今の所不明です.  measureHeightOnceのコードは以下です. 
```
dps_err_t DPS::measureHeightOnce(float &result)	
	{	
		float T, P;	
		dps_err_t ret = measureTempOnce(T);	
		if (ret != DPS__SUCCEEDED)	
		{	
			return ret;	
		}	
		ret = measurePressureOnce(P);	
		if (ret != DPS__SUCCEEDED)	
		{	
			return ret;	
		}	
		result = (std::pow((DPS__SEA_LEVEL_PRESSURE/(P/100)),(1.0/5.257)) - 1)*(T + 273.15)/0.0065;	
		return ret;	
	}
```
これを実行すると内部的にはDPS__FAIL_TOOBUSY状態になります. 